### PR TITLE
Fixes #3 because the == operator does not exist in Postgres.  = should b...

### DIFF
--- a/install/install-unit-test.sql
+++ b/install/install-unit-test.sql
@@ -267,7 +267,7 @@ CREATE FUNCTION assert.is_true(IN boolean, OUT message text, OUT result boolean)
 AS
 $$
 BEGIN
-    IF($1 == true) THEN
+    IF($1 = true) THEN
         message := 'Assert is true.';
         PERFORM assert.ok(message);
         result := true;
@@ -288,7 +288,7 @@ CREATE FUNCTION assert.is_false(IN boolean, OUT message text, OUT result boolean
 AS
 $$
 BEGIN
-    IF($1 == true) THEN
+    IF($1 = false) THEN
         message := 'Assert is false.';
         PERFORM assert.ok(message);
         result := true;


### PR DESCRIPTION
...e used instead.  Also, asset.is_false checks for true rather than false.
