### PR TITLE
Make sure the tests are executed in order they were defined.

### DIFF
--- a/install/install-unit-test.sql
+++ b/install/install-unit-test.sql
@@ -583,6 +583,7 @@ BEGIN
         ON      pronamespace = n.oid
         WHERE
             prorettype='test_result'::regtype::oid
+        ORDER BY p.oid ASC
     LOOP
         BEGIN
             _status := false;


### PR DESCRIPTION
Without ORDER BY in the query, the tests might run in random order.