### PR TITLE
Dependencies can be declared between test functions

### DIFF
--- a/install/1.install-unit-test.sql
+++ b/install/1.install-unit-test.sql
@@ -47,13 +47,15 @@ LANGUAGE plpgsql;
 
 DROP TABLE IF EXISTS unit_tests.test_details CASCADE;
 DROP TABLE IF EXISTS unit_tests.tests CASCADE;
+DROP TABLE IF EXISTS unit_tests.dependencies CASCADE;
 CREATE TABLE unit_tests.tests
 (
     test_id                                 SERIAL NOT NULL PRIMARY KEY,
     started_on                              TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     completed_on                            TIMESTAMP WITHOUT TIME ZONE NULL,
     total_tests                             integer NULL DEFAULT(0),
-    failed_tests                            integer NULL DEFAULT(0)
+    failed_tests                            integer NULL DEFAULT(0),
+    skipped_tests                           integer NULL DEFAULT(0)
 );
 
 CREATE INDEX unit_tests_tests_started_on_inx
@@ -72,7 +74,8 @@ CREATE TABLE unit_tests.test_details
     function_name                           text NOT NULL,
     message                                 text NOT NULL,
     ts                                      TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
-    status                                  boolean NOT NULL
+    status                                  boolean NOT NULL,
+    executed                                boolean NOT NULL
 );
 
 CREATE INDEX unit_tests_test_details_test_id_inx
@@ -80,6 +83,18 @@ ON unit_tests.test_details(test_id);
 
 CREATE INDEX unit_tests_test_details_status_inx
 ON unit_tests.test_details(status);
+
+CREATE TABLE unit_tests.dependencies
+(
+    dependency_id                           BIGSERIAL NOT NULL PRIMARY KEY,
+    dependent_ns                            text,
+    dependent_function_name                 text NOT NULL,
+    depends_on_ns                           text,
+    depends_on_function_name                text NOT NULL
+);
+
+CREATE INDEX unit_tests_dependencies_dependency_id_inx
+ON unit_tests.dependencies(dependency_id);
 
 
 DROP FUNCTION IF EXISTS assert.fail(message text);
@@ -572,6 +587,41 @@ LANGUAGE plpgsql
 VOLATILE;
 
 
+DROP FUNCTION IF EXISTS unit_tests.add_dependency(p_dependent text, p_depends_on text);
+CREATE FUNCTION unit_tests.add_dependency(p_dependent text, p_depends_on text)
+  RETURNS void
+AS
+  $$
+    DECLARE dependent_ns text;
+    DECLARE dependent_name text;
+    DECLARE depends_on_ns text;
+    DECLARE depends_on_name text;
+    DECLARE arr text[];
+BEGIN
+    IF p_dependent LIKE '%.%' THEN
+        SELECT regexp_split_to_array(p_dependent, E'\\.') INTO arr;
+        SELECT arr[1] INTO dependent_ns;
+        SELECT arr[2] INTO dependent_name;
+    ELSE
+        SELECT NULL INTO dependent_ns;
+        SELECT p_dependent INTO dependent_name;
+    END IF;
+    IF p_depends_on LIKE '%.%' THEN
+        SELECT regexp_split_to_array(p_depends_on, E'\\.') INTO arr;
+        SELECT arr[1] INTO depends_on_ns;
+        SELECT arr[2] INTO depends_on_name;
+    ELSE
+        SELECT NULL INTO depends_on_ns;
+        SELECT p_depends_on INTO depends_on_name;
+    END IF;
+    INSERT INTO unit_tests.dependencies (dependent_ns, dependent_function_name, depends_on_ns, depends_on_function_name)
+    VALUES (dependent_ns, dependent_name, depends_on_ns, depends_on_name);
+END
+$$
+LANGUAGE plpgsql
+STRICT;
+
+
 DROP FUNCTION IF EXISTS unit_tests.begin(verbosity integer, format text);
 CREATE FUNCTION unit_tests.begin(verbosity integer DEFAULT 9, format text DEFAULT '')
 RETURNS TABLE(message text, result character(1))
@@ -580,124 +630,198 @@ $$
     DECLARE this                    record;
     DECLARE _function_name          text;
     DECLARE _sql                    text;
+    DECLARE _failed_dependencies    text[];
+    DECLARE _num_of_test_functions  integer;
+    DECLARE _should_skip            boolean;
     DECLARE _message                text;
+    DECLARE _error                  text;
     DECLARE _result                 character(1);
     DECLARE _test_id                integer;
     DECLARE _status                 boolean;
     DECLARE _total_tests            integer                         = 0;
     DECLARE _failed_tests           integer                         = 0;
+    DECLARE _skipped_tests          integer                         = 0;
     DECLARE _list_of_failed_tests   text;
+    DECLARE _list_of_skipped_tests  text;
     DECLARE _started_from           TIMESTAMP WITHOUT TIME ZONE;
     DECLARE _completed_on           TIMESTAMP WITHOUT TIME ZONE;
     DECLARE _delta                  integer;
     DECLARE _ret_val                text                            = '';
-    DECLARE _verbosity              text[]                          = 
+    DECLARE _verbosity              text[]                          =
                                     ARRAY['debug5', 'debug4', 'debug3', 'debug2', 'debug1', 'log', 'notice', 'warning', 'error', 'fatal', 'panic'];
 BEGIN
     _started_from := clock_timestamp() AT TIME ZONE 'UTC';
 
     IF(format='teamcity') THEN
-        RAISE INFO '##teamcity[testSuiteStarted name=''Plpgunit'' message=''Test started from : %'']', _started_from; 
+        RAISE INFO '##teamcity[testSuiteStarted name=''Plpgunit'' message=''Test started from : %'']', _started_from;
     ELSE
-        RAISE INFO 'Test started from : %', _started_from; 
+        RAISE INFO 'Test started from : %', _started_from;
     END IF;
-    
+
     IF($1 > 11) THEN
         $1 := 9;
     END IF;
-    
+
     EXECUTE 'SET CLIENT_MIN_MESSAGES TO ' || _verbosity[$1];
     RAISE WARNING 'CLIENT_MIN_MESSAGES set to : %' , _verbosity[$1];
-    
+
     SELECT nextval('unit_tests.tests_test_id_seq') INTO _test_id;
 
     INSERT INTO unit_tests.tests(test_id)
     SELECT _test_id;
 
+    DROP TABLE IF EXISTS temp_test_functions;
+    CREATE TEMP TABLE temp_test_functions AS
+    SELECT
+        nspname AS ns_name,
+        proname AS function_name,
+        p.oid as oid
+    FROM    pg_catalog.pg_namespace n
+    JOIN    pg_catalog.pg_proc p
+    ON      pronamespace = n.oid
+    WHERE
+        prorettype='test_result'::regtype::oid;
+
+    SELECT count(*) INTO _num_of_test_functions FROM temp_test_functions;
+
+    DROP TABLE IF EXISTS temp_dependency_levels;
+    CREATE TEMP TABLE temp_dependency_levels AS
+    WITH RECURSIVE dependency_levels(ns_name, function_name, oid, level) AS (
+      -- select functions without any dependencies
+      SELECT ns_name, function_name, tf.oid, 0 as level
+      FROM temp_test_functions tf
+      LEFT OUTER JOIN unit_tests.dependencies d ON tf.ns_name = d.dependent_ns AND tf.function_name = d.dependent_function_name
+      WHERE d.dependency_id IS NULL
+      UNION
+      -- add functions which depend on the previous level functions
+      SELECT d.dependent_ns, d.dependent_function_name, tf.oid, level + 1
+      FROM dependency_levels dl
+      JOIN unit_tests.dependencies d ON dl.ns_name = d.depends_on_ns AND dl.function_name LIKE d.depends_on_function_name
+      JOIN temp_test_functions tf ON d.dependent_ns = tf.ns_name AND d.dependent_function_name = tf.function_name
+      WHERE level < _num_of_test_functions -- don't follow circles for too long
+      )
+      SELECT ns_name, function_name, oid, max(level) as max_level
+      FROM dependency_levels
+      GROUP BY ns_name, function_name, oid;
+
+    IF (SELECT count(*) < _num_of_test_functions FROM temp_dependency_levels) THEN
+      SELECT array_to_string(array_agg(tf.ns_name || '.' || tf.function_name || '()'), ', ')
+      INTO _error
+      FROM temp_test_functions tf
+      LEFT OUTER JOIN temp_dependency_levels dl ON tf.oid = dl.oid
+        WHERE dl.oid IS NULL;
+      RAISE EXCEPTION 'Cyclic dependencies detected. Check the following test functions: %', _error;
+    END IF;
+
+    IF exists(SELECT * FROM temp_dependency_levels WHERE max_level = _num_of_test_functions) THEN
+      SELECT array_to_string(array_agg(ns_name || '.' || function_name || '()'), ', ')
+        INTO _error
+        FROM temp_dependency_levels
+        WHERE max_level = _num_of_test_functions;
+      RAISE EXCEPTION 'Cyclic dependencies detected. Check the dependency graph including following test functions: %', _error;
+    END IF;
+
     FOR this IN
-        SELECT 
-            nspname AS ns_name,
-            proname AS function_name
-        FROM    pg_catalog.pg_namespace n
-        JOIN    pg_catalog.pg_proc p
-        ON      pronamespace = n.oid
-        WHERE
-            prorettype='test_result'::regtype::oid
-        ORDER BY p.oid ASC
+      SELECT ns_name, function_name, max_level
+        FROM temp_dependency_levels
+        ORDER BY max_level, oid
     LOOP
         BEGIN
             _status := false;
             _total_tests := _total_tests + 1;
-            
+
             _function_name = this.ns_name|| '.' || this.function_name || '()';
-            _sql := 'SELECT ' || _function_name || ';';
-            
-            RAISE NOTICE 'RUNNING TEST : %.', _function_name;
 
-            IF(format='teamcity') THEN
-                RAISE INFO '##teamcity[testStarted name=''%'' message=''%'']', _function_name, _started_from; 
+            SELECT array_agg(td.function_name)
+                INTO _failed_dependencies
+                FROM unit_tests.dependencies d
+                JOIN unit_tests.test_details td on td.function_name LIKE d.depends_on_ns || '.' || d.depends_on_function_name || '()'
+                WHERE d.dependent_ns = this.ns_name AND d.dependent_function_name = this.function_name
+                AND test_id = _test_id AND status = false;
+
+            SELECT _failed_dependencies IS NOT NULL INTO _should_skip;
+            IF NOT _should_skip THEN
+                _sql := 'SELECT ' || _function_name || ';';
+
+                RAISE NOTICE 'RUNNING TEST : %.', _function_name;
+
+                IF(format='teamcity') THEN
+                    RAISE INFO '##teamcity[testStarted name=''%'' message=''%'']', _function_name, _started_from;
+                ELSE
+                    RAISE INFO 'Running test % : %', _function_name, _started_from;
+                END IF;
+
+                EXECUTE _sql INTO _message;
+
+                IF _message = '' THEN
+                    _status := true;
+
+                    IF(format='teamcity') THEN
+                        RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
+                    ELSE
+                        RAISE INFO 'Passed % : %', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
+                    END IF;
+                ELSE
+                    IF(format='teamcity') THEN
+                        RAISE INFO '##teamcity[testFailed name=''%'' message=''%'']', _function_name, _message;
+                        RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
+                    ELSE
+                        RAISE INFO 'Test failed % : %', _function_name, _message;
+                    END IF;
+                END IF;
             ELSE
-                RAISE INFO 'Running test % : %', _function_name, _started_from; 
-            END IF;
-            
-            EXECUTE _sql INTO _message;
-
-            IF _message = '' THEN
+                -- skipped test
                 _status := true;
-
+                _message = 'Failed dependencies: ' || array_to_string(_failed_dependencies, ',');
                 IF(format='teamcity') THEN
-                    RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC'; 
+                    RAISE INFO '##teamcity[testSkipped name=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
                 ELSE
-                    RAISE INFO 'Passed % : %', _function_name, clock_timestamp() AT TIME ZONE 'UTC'; 
-                END IF;
-            ELSE
-                IF(format='teamcity') THEN
-                    RAISE INFO '##teamcity[testFailed name=''%'' message=''%'']', _function_name, _message; 
-                    RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC'; 
-                ELSE
-                    RAISE INFO 'Test failed % : %', _function_name, _message; 
+                    RAISE INFO 'Skipped % : %', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
                 END IF;
             END IF;
-            
-            INSERT INTO unit_tests.test_details(test_id, function_name, message, status, ts)
-            SELECT _test_id, _function_name, _message, _status, clock_timestamp();
+
+            INSERT INTO unit_tests.test_details(test_id, function_name, message, status, executed, ts)
+            SELECT _test_id, _function_name, _message, _status, NOT _should_skip, clock_timestamp();
 
             IF NOT _status THEN
-                _failed_tests := _failed_tests + 1;         
+                _failed_tests := _failed_tests + 1;
                 RAISE WARNING 'TEST % FAILED.', _function_name;
                 RAISE WARNING 'REASON: %', _message;
-            ELSE
+            ELSIF NOT _should_skip THEN
                 RAISE NOTICE 'TEST % COMPLETED WITHOUT ERRORS.', _function_name;
+            ELSE
+                _skipped_tests := _skipped_tests + 1;
+                RAISE WARNING 'TEST % SKIPPED, BECAUSE A DEPENDENCY FAILED.', _function_name;
             END IF;
 
         EXCEPTION WHEN OTHERS THEN
             _message := 'ERR' || SQLSTATE || ': ' || SQLERRM;
-            INSERT INTO unit_tests.test_details(test_id, function_name, message, status)
-            SELECT _test_id, _function_name, _message, false;
+            INSERT INTO unit_tests.test_details(test_id, function_name, message, status, executed)
+            SELECT _test_id, _function_name, _message, false, true;
 
-            _failed_tests := _failed_tests + 1;         
+            _failed_tests := _failed_tests + 1;
 
             RAISE WARNING 'TEST % FAILED.', _function_name;
             RAISE WARNING 'REASON: %', _message;
 
             IF(format='teamcity') THEN
-                RAISE INFO '##teamcity[testFailed name=''%'' message=''%'']', _function_name, _message; 
-                RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC'; 
+                RAISE INFO '##teamcity[testFailed name=''%'' message=''%'']', _function_name, _message;
+                RAISE INFO '##teamcity[testFinished name=''%'' message=''%'']', _function_name, clock_timestamp() AT TIME ZONE 'UTC';
             ELSE
-                RAISE INFO 'Test failed % : %', _function_name, _message; 
+                RAISE INFO 'Test failed % : %', _function_name, _message;
             END IF;
         END;
     END LOOP;
 
     _completed_on := clock_timestamp() AT TIME ZONE 'UTC';
     _delta := extract(millisecond from _completed_on - _started_from)::integer;
-    
+
     UPDATE unit_tests.tests
-    SET total_tests = _total_tests, failed_tests = _failed_tests, completed_on = _completed_on
+    SET total_tests = _total_tests, failed_tests = _failed_tests, skipped_tests = _skipped_tests, completed_on = _completed_on
     WHERE test_id = _test_id;
 
     IF format='junit' THEN
-        SELECT 
+        SELECT
             '<?xml version="1.0" encoding="UTF-8"?>'||
             xmlelement
             (
@@ -707,10 +831,10 @@ BEGIN
                     name                    testsuite,
                     xmlattributes
                     (
-                        'plpgunit'          AS name, 
-                        t.total_tests       AS tests, 
-                        t.failed_tests      AS failures, 
-                        0                   AS errors, 
+                        'plpgunit'          AS name,
+                        t.total_tests       AS tests,
+                        t.failed_tests      AS failures,
+                        0                   AS errors,
                         EXTRACT
                         (
                             EPOCH FROM t.completed_on - t.started_on
@@ -720,24 +844,24 @@ BEGIN
                     (
                         xmlelement
                         (
-                            name testcase, 
+                            name testcase,
                             xmlattributes
                             (
                                 td.function_name
-                                            AS name, 
+                                            AS name,
                                 EXTRACT
                                 (
                                     EPOCH FROM td.ts - t.started_on
                                 )           AS time
                             ),
-                            CASE 
-                                WHEN td.status=false 
-                                THEN 
+                            CASE
+                                WHEN td.status=false
+                                THEN
                                     xmlelement
                                     (
-                                        name failure, 
+                                        name failure,
                                         td.message
-                                    ) 
+                                    )
                                 END
                         )
                     )
@@ -746,39 +870,54 @@ BEGIN
         FROM unit_tests.test_details td, unit_tests.tests t
         WHERE
             t.test_id=_test_id
-        AND 
+        AND
             td.test_id=t.test_id
         GROUP BY t.test_id;
     ELSE
         WITH failed_tests AS
         (
-            SELECT row_number() OVER (ORDER BY id) AS id, 
+            SELECT row_number() OVER (ORDER BY id) AS id,
                 unit_tests.test_details.function_name,
                 unit_tests.test_details.message
-            FROM unit_tests.test_details 
+            FROM unit_tests.test_details
             WHERE test_id = _test_id
             AND status= false
         )
-        SELECT array_to_string(array_agg(f.id::text || '. ' || f.function_name || ' --> ' || f.message), E'\n') INTO _list_of_failed_tests 
+        SELECT array_to_string(array_agg(f.id::text || '. ' || f.function_name || ' --> ' || f.message), E'\n') INTO _list_of_failed_tests
         FROM failed_tests f;
+
+        WITH skipped_tests AS
+        (
+            SELECT row_number() OVER (ORDER BY id) AS id,
+                unit_tests.test_details.function_name,
+                unit_tests.test_details.message
+            FROM unit_tests.test_details
+            WHERE test_id = _test_id
+            AND executed = false
+        )
+        SELECT array_to_string(array_agg(s.id::text || '. ' || s.function_name || ' --> ' || s.message), E'\n') INTO _list_of_skipped_tests
+        FROM skipped_tests s;
 
         _ret_val := _ret_val ||  'Test completed on : ' || _completed_on::text || E' UTC. \nTotal test runtime: ' || _delta::text || E' ms.\n';
         _ret_val := _ret_val || E'\nTotal tests run : ' || COALESCE(_total_tests, '0')::text;
-        _ret_val := _ret_val || E'.\nPassed tests    : ' || (COALESCE(_total_tests, '0') - COALESCE(_failed_tests, '0'))::text;
+        _ret_val := _ret_val || E'.\nPassed tests    : ' || (COALESCE(_total_tests, '0') - COALESCE(_failed_tests, '0') - COALESCE(_skipped_tests, '0'))::text;
         _ret_val := _ret_val || E'.\nFailed tests    : ' || COALESCE(_failed_tests, '0')::text;
+        _ret_val := _ret_val || E'.\nSkipped tests   : ' || COALESCE(_skipped_tests, '0')::text;
         _ret_val := _ret_val || E'.\n\nList of failed tests:\n' || '----------------------';
         _ret_val := _ret_val || E'\n' || COALESCE(_list_of_failed_tests, '<NULL>')::text;
+        _ret_val := _ret_val || E'.\n\nList of skipped tests:\n' || '----------------------';
+        _ret_val := _ret_val || E'\n' || COALESCE(_list_of_skipped_tests, '<NULL>')::text;
         _ret_val := _ret_val || E'\n' || E'End of plpgunit test.\n\n';
     END IF;
-    
+
     IF _failed_tests > 0 THEN
         _result := 'N';
 
         IF(format='teamcity') THEN
-            RAISE INFO '##teamcity[testStarted name=''Result'']'; 
-            RAISE INFO '##teamcity[testFailed name=''Result'' message=''%'']', REPLACE(_ret_val, E'\n', ' |n'); 
-            RAISE INFO '##teamcity[testFinished name=''Result'']'; 
-            RAISE INFO '##teamcity[testSuiteFinished name=''Plpgunit'' message=''%'']', REPLACE(_ret_val, E'\n', '|n'); 
+            RAISE INFO '##teamcity[testStarted name=''Result'']';
+            RAISE INFO '##teamcity[testFailed name=''Result'' message=''%'']', REPLACE(_ret_val, E'\n', ' |n');
+            RAISE INFO '##teamcity[testFinished name=''Result'']';
+            RAISE INFO '##teamcity[testSuiteFinished name=''Plpgunit'' message=''%'']', REPLACE(_ret_val, E'\n', '|n');
         ELSE
             RAISE INFO '%', _ret_val;
         END IF;
@@ -786,14 +925,14 @@ BEGIN
         _result := 'Y';
 
         IF(format='teamcity') THEN
-            RAISE INFO '##teamcity[testSuiteFinished name=''Plpgunit'' message=''%'']', REPLACE(_ret_val, E'\n', '|n'); 
+            RAISE INFO '##teamcity[testSuiteFinished name=''Plpgunit'' message=''%'']', REPLACE(_ret_val, E'\n', '|n');
         ELSE
             RAISE INFO '%', _ret_val;
         END IF;
     END IF;
 
     SET CLIENT_MIN_MESSAGES TO notice;
-    
+
     RETURN QUERY SELECT _ret_val, _result;
 END
 $$


### PR DESCRIPTION
- Adding new table: dependencies
- Adding new function: add_dependency
- Modifying the begin function to execute unit tests in the order of
  dependencies
- Tests are skipped if at least one of their dependencies fail
- No tests are executed if there are cyclic dependencies
- The stats contain skipped tests